### PR TITLE
Remove log output on page navigation

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,5 +1,4 @@
 export const onRouteUpdate = () => {
-    console.log('$pageview', arguments)
     if (window.posthog) {
         window.posthog.capture('$pageview')
     }


### PR DESCRIPTION
Noticed that there was a message being output to the console on page navigation -- just dropping it to reduce noise since it looks like it might have been for testing purposes.