### PR TITLE
Relax restrictions on gatsby and react versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "@testing-library/react": "^11.2.2",
     "babel-preset-gatsby-package": "^0.7.0",
     "cross-env": "^7.0.2",
-    "gatsby": "^2.20.29",
-    "react": "^17.0.1"
+    "gatsby": ">=2.0.0",
+    "react": ">=16.4.2"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0",
-    "react": "^16.4.2",
-    "react-dom": "^16.4.2"
+    "gatsby": ">=2.0.0",
+    "react": ">=16.4.2",
+    "react-dom": ">=16.4.2"
   },
   "keywords": [
     "gatsby",


### PR DESCRIPTION
I haven't done extensive testing but force installing this package in a Gatsby 5 project works just fine. Can you please consider relaxing the version restrictions so this can be used in new Gatsby apps? Thank you!